### PR TITLE
Fix/8.1 y 8.2 el botón de eliminar incidencias aparece a usuarios sin permisos y boton para INPROGRESS

### DIFF
--- a/backend/api/incidents/incidents.py
+++ b/backend/api/incidents/incidents.py
@@ -2,7 +2,7 @@ import cloudinary
 import cloudinary.uploader
 from api.chat.chat_helpers import verify_association_membership
 from core.config import settings
-from core.deps import get_current_user, get_supabase
+from core.deps import get_current_user, get_supabase, get_supabase_admin
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from schemas.incidents.incidents import Incident
 from services.helpers.role_service import get_user_role
@@ -268,6 +268,7 @@ def discard_incident(
     incident_id: str,
     current_user: dict = Depends(get_current_user),
     supabase: Client = Depends(get_supabase),
+    supabase_admin: Client = Depends(get_supabase_admin),
 ):
     user_id = current_user["id"]
     role = str(get_user_role(supabase, association_id, user_id))
@@ -279,11 +280,11 @@ def discard_incident(
 
     latest_state = get_latest_state(supabase, incident_id)
 
-    if latest_state.get("status") not in {"PENDING", "DISCARDED", "SOLVED"}:
+    if latest_state.get("status") not in {"PENDING", "IN PROGRESS", "DISCARDED", "SOLVED"}:
         raise HTTPException(status_code=409, detail="La incidencia no puede ser eliminada en su estado actual")
 
     try:
-        supabase.table("incident_states").delete().eq("incident_id", incident_id).execute()
-        supabase.table("incidents").delete().eq("id", incident_id).execute()
+        supabase_admin.table("incident_states").delete().eq("incident_id", incident_id).execute()
+        supabase_admin.table("incidents").delete().eq("id", incident_id).execute()
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error al eliminar la incidencia: {str(e)}")

--- a/frontend/app/(drawer)/[communityId]/incidencias.tsx
+++ b/frontend/app/(drawer)/[communityId]/incidencias.tsx
@@ -310,7 +310,7 @@ export default function IncidenciasScreen() {
     const isAdminOrPresident = roleToken === '1' || roleToken === '4';
     const canDeleteThis =
       (isAdminOrPresident || isOwner) &&
-      ['PENDING', 'SOLVED', 'DISCARDED'].includes(item.status);
+      ['PENDING', 'IN PROGRESS', 'SOLVED', 'DISCARDED'].includes(item.status);
 
     return (
       <IncidentCard

--- a/frontend/components/community/incidents/constants.ts
+++ b/frontend/components/community/incidents/constants.ts
@@ -20,7 +20,7 @@ type IconComponent = ComponentType<{ size?: number; color?: string }>;
 export type StatusTone = { text: string; bg: string; border: string };
 
 export const STATUS_TONE: Record<IncidentStatus, StatusTone> = {
-  PENDING: { text: '#B42318', bg: '#FEE4E2', border: '#FECDCA' },
+  PENDING: { text: '#B54708', bg: '#FEF9C3', border: '#FDE68A' },
   'IN PROGRESS': { text: '#B54708', bg: '#FEF0C7', border: '#FEDF89' },
   SOLVED: { text: '#067647', bg: '#D1FADF', border: '#A6F4C5' },
   DISCARDED: { text: '#991B1B', bg: '#FEE2E2', border: '#FECACA' },


### PR DESCRIPTION
Actualmente, el botón para eliminar incidencias se muestra a usuarios que no tienen permisos para realizar esta acción. Cuando estos usuarios intentan eliminar una incidencia, el backend responde con un error Unauthorized.

Además, los usuarios que sí deberían poder eliminar sus propias incidencias actualmente no pueden hacerlo.

También se ha detectado un comportamiento confuso con incidencias en estado IN PROGRESS: el backend no permite eliminarlas, pero la interfaz no informa claramente de esta restricción al usuario.

El problema está en que la lógica actual únicamente comprueba el estado de la incidencia, pero no valida:

la autoría de la incidencia,
los permisos del usuario autenticado,
ni las restricciones específicas según el estado.
Archivos afectados

Frontend:
frontend/app/(drawer)/[communityId]/incidencias.tsx

Backend:
incidents.py:282

Código actual
const canDeleteThis = ['PENDING', 'SOLVED', 'DISCARDED'].includes(status);
Impacto
Usuarios sin permisos visualizan acciones que no pueden ejecutar.
Se producen errores Unauthorized innecesarios.
Mala experiencia de usuario.
Los creadores de incidencias no pueden gestionar correctamente sus propias incidencias.
Confusión al intentar eliminar incidencias en estado IN PROGRESS.
Comportamiento esperado

El botón de eliminar solo debe mostrarse cuando:

el usuario sea el creador de la incidencia,
o tenga permisos de administrador/presidente.

Además:

Debe definirse claramente el comportamiento para incidencias IN PROGRESS.
Si no pueden eliminarse, debe mostrarse un mensaje explícito al usuario indicando:
"No se pueden eliminar incidencias en curso."
Alternativamente, permitir que administradores eliminen incidencias en cualquier estado.
Lógica esperada
const canDeleteThis =
  (incident.creator_id === user.id || isAdminOrPresident) &&
  ['PENDING', 'SOLVED', 'DISCARDED'].includes(status);